### PR TITLE
Add file ext to allow build tools that use header2 to install

### DIFF
--- a/ivy-point-history.el
+++ b/ivy-point-history.el
@@ -1,4 +1,4 @@
-;;; ivy-point-history --- point-history with ivy interface
+;;; ivy-point-history.el --- point-history with ivy interface
 
 ;; Copyright (C) 2019 SuzumiyaAoba
 
@@ -55,7 +55,7 @@
 (defun ivy-point-history--action (point)
   (let* ((buffer-name (get-text-property 0 'point-history-buffer point))
 	 (pos-str (get-text-property 0 'point-history-position point)))
-    (if (or (null buffer-name) (null pos-str)) 
+    (if (or (null buffer-name) (null pos-str))
 	(message "No point at this line.")
       (with-ivy-window
         (let ((buffer (get-buffer buffer-name))
@@ -77,4 +77,4 @@
 
 (provide 'ivy-point-history)
 
-;;; ivy-point-history.el ends here
+;;; ivy-point-history ends here


### PR DESCRIPTION
This change allows point-history to be installed via Quelpa, which requires a header2.el conformant file header section.  Either a mode declaration or file ext is required.

Reference: https://www.emacswiki.org/emacs/AutomaticFileHeaders

> Why should I place -*- Mode: Emacs-Lisp -*- at the top? header2.el works for any time of file, not just EmacsLisp files. And for Emacs-Lisp files that have file extension el or elc there is no need for a mode declaration in the header.

By adding the file ext, the file header path is recognized by package building tools.

Example: The following will only work when the header file name is specified.

```elisp
(package-install 'quelpa-use-package)
(require 'quelpa-use-package)

(use-package popwin :defer t)

;; working - with file ext
(use-package ivy-point-history
  :defer t
  :after (popwin)
  :quelpa (ivy-point-history :fetcher github :repo "jclosure/ivy-point-history"))

;; not working - no file ext
(use-package ivy-point-history
  :defer t
  :after (popwin)
  :quelpa (ivy-point-history :fetcher github :repo "SuzumiyaAoba/ivy-point-history"))
```

Issue is:
```
Debugger entered--Lisp error: (error "Package lacks a file header")
  signal(error ("Package lacks a file header"))
  error("Package lacks a file header")
  package-buffer-info()
  quelpa-get-package-desc("/Users/jholder/.emacs.d/quelpa/packages/ivy-point-history-20190507.2154.el")
  quelpa-package-install((ivy-point-history :fetcher github :repo "SuzumiyaAoba/ivy-point-history"))
  apply(quelpa-package-install (ivy-point-history :fetcher github :repo "SuzumiyaAoba/ivy-point-history") nil)
  quelpa((ivy-point-history :fetcher github :repo "SuzumiyaAoba/ivy-point-history"))
  eval((quelpa '(ivy-point-history :fetcher github :repo "SuzumiyaAoba/ivy-point-history")) nil)
  elisp--eval-last-sexp(nil)
  eval-last-sexp(nil)
  funcall-interactively(eval-last-sexp nil)
  call-interactively(eval-last-sexp nil nil)
  command-execute(eval-last-sexp)
```
